### PR TITLE
Potential fix for code scanning alert no. 2: Use of externally-controlled format string

### DIFF
--- a/backend/netlify/functions/api.js
+++ b/backend/netlify/functions/api.js
@@ -30,7 +30,7 @@ app.get('/history/:symbol', async (req, res) => {
     const history = getStockHistory(symbol, period);
     res.json(history);
   } catch (error) {
-    console.error(`Error fetching history for ${req.params.symbol}:`, error);
+    console.error('Error fetching history for %s:', req.params.symbol, error);
     res.status(500).json({ error: `Failed to fetch history for ${req.params.symbol}` });
   }
 });


### PR DESCRIPTION
Potential fix for [https://github.com/Sai-Dangade777/Stock-Market-Dashboard/security/code-scanning/2](https://github.com/Sai-Dangade777/Stock-Market-Dashboard/security/code-scanning/2)

To fix this problem, always avoid placing untrusted data directly into the format string when logging. Instead, use a static format string with a `%s` and pass the untrusted data as an argument, preventing it from being interpreted as a format specifier. In this codebase, replace any interpolation or concatenation of user input into log message format strings with the use of explicit `%s` placeholders.

**In detail:**  
- In `backend/netlify/functions/api.js`, locate line 33 and change:
  ```js
  console.error(`Error fetching history for ${req.params.symbol}:`, error);
  ```
  to
  ```js
  console.error('Error fetching history for %s:', req.params.symbol, error);
  ```
- No new methods or imports are necessary for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
